### PR TITLE
Deploy scheduler on separate thread during app creation

### DIFF
--- a/happiness-backend/api/app.py
+++ b/happiness-backend/api/app.py
@@ -9,6 +9,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 import api.email_methods as email_methods
 from config import Config
+from jobs import scheduler
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -21,7 +22,8 @@ cors = CORS()
 def create_app(config=Config):
     app = Flask(__name__)
     app.config.from_object(config)
-
+    app.redis = redis.from_url(app.config['REDISCLOUD_URL'])
+    app.job_queue = rq.Queue('happiness-backend-jobs', connection=app.redis)
     # Do not remove!
     from api import models
 
@@ -31,6 +33,7 @@ def create_app(config=Config):
     apifairy.init_app(app)
     email_methods.init_app(app)
     cors.init_app(app)
+    scheduler.init_app(app)
 
     from api.user import user
     app.register_blueprint(user, url_prefix='/api/user')
@@ -44,9 +47,6 @@ def create_app(config=Config):
     app.register_blueprint(journal, url_prefix='/api/journal')
     from api.errors import errors
     app.register_blueprint(errors)
-
-    app.redis = redis.from_url(app.config['REDISCLOUD_URL'])
-    app.job_queue = rq.Queue('happiness-backend-jobs', connection=app.redis)
 
     @app.route('/')
     @app.route('/api')

--- a/happiness-backend/api/token.py
+++ b/happiness-backend/api/token.py
@@ -1,11 +1,9 @@
 from apifairy import authenticate, response, other_responses
 from flask import Blueprint, request
 
-from api.models import Token
-from api.dao.users_dao import get_token
-from api.auth import basic_auth, token_auth
-
 from api.app import db
+from api.auth import basic_auth, token_auth
+from api.dao.users_dao import get_token
 from api.errors import failure_response
 from api.schema import TokenSchema, PasswordKeySchema
 
@@ -30,15 +28,14 @@ def new_token():
     if user.encrypted_key is None:
         user.e2e_init(request.authorization.password)
 
-    Token.clean()
     db.session.commit()
 
     return ({
-        'session_token': token.session_token
-    },
-        {
-        'Password-Key': user.derive_pwd_key(request.authorization.password)
-    })
+                'session_token': token.session_token
+            },
+            {
+                'Password-Key': user.derive_pwd_key(request.authorization.password)
+            })
 
 
 @token.delete('/')

--- a/happiness-backend/jobs/jobs.py
+++ b/happiness-backend/jobs/jobs.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import uuid
 from datetime import datetime, timedelta
 
 import redis

--- a/happiness-backend/jobs/scheduler.py
+++ b/happiness-backend/jobs/scheduler.py
@@ -44,10 +44,6 @@ def run_schedule(app):
         scheduler_log("Queuing job for sending notification emails")
         q.enqueue("jobs.jobs.queue_send_notification_emails")
 
-    @sched.scheduled_job('interval', seconds=10)
-    def test_job():
-        scheduler_log("Queuing job test job")
-
     scheduler_log("Starting scheduler")
     sched.start()
 

--- a/happiness-backend/jobs/scheduler.py
+++ b/happiness-backend/jobs/scheduler.py
@@ -1,9 +1,7 @@
-import os
+from threading import Thread
 
-import redis
 from apscheduler.schedulers.blocking import BlockingScheduler
-from dotenv import load_dotenv
-from rq import Queue
+from colorama import Fore, Style
 
 """
 scheduler.py is the publisher responsible for publishing jobs to the redis db. 
@@ -18,28 +16,46 @@ Interval jobs:
 https://apscheduler.readthedocs.io/en/3.x/modules/triggers/interval.html
 """
 
-sched = BlockingScheduler()
-
-load_dotenv()
-redis_url = os.getenv('REDISCLOUD_URL')
-
-conn = redis.from_url(redis_url)
-q = Queue('happiness-backend-jobs', connection=conn)
+scheduler_color = Fore.CYAN
+is_scheduler_running = False
 
 
-@sched.scheduled_job('interval', days=1)
-def scheduled_clear_exported_happiness():
-    q.enqueue("jobs.jobs.clear_exported_happiness")
+# Run scheduler on separate thread in main server to avoid Heroku fees
+# When testing, multiple schedulers may be created.
+# This is because the production server has restarts.
+# Use the terminal option `--no-reload` to fix this.
+def run_schedule(app):
+    sched = BlockingScheduler()
+
+    q = app.job_queue
+
+    @sched.scheduled_job('interval', days=1)
+    def scheduled_clear_exported_happiness():
+        scheduler_log("Queuing job for exporting happiness")
+        q.enqueue("jobs.jobs.clear_exported_happiness")
+
+    @sched.scheduled_job('interval', days=1)
+    def scheduled_clean_tokens():
+        scheduler_log("Queuing job for cleaning tokens")
+        q.enqueue("jobs.jobs.clean_tokens")
+
+    @sched.scheduled_job('cron', minute="0,30")
+    def scheduled_queue_send_notification_emails():
+        scheduler_log("Queuing job for sending notification emails")
+        q.enqueue("jobs.jobs.queue_send_notification_emails")
+
+    @sched.scheduled_job('interval', seconds=10)
+    def test_job():
+        scheduler_log("Queuing job test job")
+
+    scheduler_log("Starting scheduler")
+    sched.start()
 
 
-@sched.scheduled_job('interval', days=1)
-def scheduled_clean_tokens():
-    q.enqueue("jobs.jobs.clean_tokens")
+def init_app(app):
+    thread = Thread(target=run_schedule, args=(app,))
+    thread.start()
 
 
-@sched.scheduled_job('cron', minute="0,30")
-def scheduled_queue_send_notification_emails():
-    q.enqueue("jobs.jobs.queue_send_notification_emails")
-
-
-sched.start()
+def scheduler_log(text: str):
+    print(scheduler_color + text + Style.RESET_ALL)


### PR DESCRIPTION
# Scheduler deployment
This PR adds an `init_app` function to the scheduler for it to run during the Flask app initialization. This way when the app is created, the scheduler will automatically be running on a separate thread and it will push tasks to the Redis cloud instance. When this PR is merged, I will also deploy a worker manually on Heroku. 
## Changes made
- Refactored scheduler to run in a separate thread when `init_app` function is called.
- Changed location of `app.redis` and `app.job_queue` initialization.
## Note
- Currently when you do `flask run`, 2 scheduler instances run. This is because Flask supports auto-reload for development purposes. A Flask app in production does not have auto-reload, so it shouldn't run a second scheduler instance. When this is deployed I advise checking the logs to ensure that only one scheduler is deployeed.