### PR TITLE
Add auto-save networking for the side bar

### DIFF
--- a/happiness-frontend/src/pages/SubmitHappiness.js
+++ b/happiness-frontend/src/pages/SubmitHappiness.js
@@ -374,7 +374,7 @@ export default function SubmitHappiness() {
   }
 }
 
-function formatDate(date) {
+export function formatDate(date) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");


### PR DESCRIPTION
## Changes made
Added auto-save networking for the sidebar using React query and `useEffect` hook.
## Known issues
The page sends a create request to the endpoint when loaded. This is ok though because it is "overriding" the happiness with the same entry. This inefficiency could be bad for a very large scale app but for Happiness App we do not need the premature optimization. Fixing it with a simple check to see if the page has rendered won't work since the network request to load happiness that is currently on the page changes the happiness, triggering another request.